### PR TITLE
[FEAT] Use this as default context

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ A use case for `context-id` helper is to programmatically associate labels and i
 
 ```hbs
 // components/my-input.hbs
-<label for={{context-id this}}>Input Label</label>
-<input id={{context-id this}} type="text"/>
+<label for="{{context-id this}}-input">Input Label</label>
+<input id="{{context-id this}}-input" type="text"/>
 ```
 
 When used in a template the previous component template will render an input and is associated label.
@@ -44,25 +44,23 @@ For exemple the folowing code :
 Will render
 
 ```hbs
-<label for="ember-xx1">Input Label</label>
-<input id="ember-xx1" type="text"/>
-<label for="ember-xx2">Input Label</label>
-<input id="ember-xx2" type="text"/>
-
+<label for="emberxx1-input">Input Label</label>
+<input id="emberxx1-input" type="text"/>
+<label for="emberxx2-input">Input Label</label>
+<input id="emberxx2-input" type="text"/>
 ```
 
-The `context-id` helper require a context to generate the unique id. A context can be any object, string, number, Element, or primitive, however we recommend not using a string or a number because `context-id` will generate the same id for the same value.
+By default `context-id` will use a component/template `this` as context but you can also manually provide a context if you want.
+A context can be any object, string, number, Element, or primitive, however we recommend not using a string or a number because `context-id` will generate the same id for the same value.
 For example if you you modify the previous example like this:
 
 ```hbs
 // components/my-input.hbs
-<label for={{context-id "my-input"}}>Input Label</label>
-<input id={{context-id "my-input"}} type="text"/>
+<label for="{{context-id "my-input"}}-input">Input Label</label>
+<input id="{{context-id "my-input"}}-input" type="text"/>
 ```
 
 All uses of `MyInput` will generate an input with the same id.
-
-The easiest way to ensure that components (or route templates) using `context-id` doesn't share the same ids, is to provide the helper with the component/template `this` context.
 
 Limitations
 ------------------------------------------------------------------------------
@@ -72,7 +70,7 @@ You cannot use `{{context-id this}}` in template only glimmer components as they
 Todo
 ------------------------------------------------------------------------------
 
-* [ ] Implicitely get current context
+* [x] Implicitely get current context
 * [ ] Make it work with template only glimmer component
     (For thoses component `this` is `undefined`)
 

--- a/addon/helpers/context-id.js
+++ b/addon/helpers/context-id.js
@@ -3,7 +3,7 @@ import { guidFor } from '@ember/object/internals';
 import { assert } from '@ember/debug';
 import { isNone } from '@ember/utils';
 
-export default helper(function uniqueId(params/*, hash*/) {
+export default helper(function(params/*, hash*/) {
   let [context] = params;
   assert('You must provide a context to `context-id` helper. Try `{{context-id this}}`.', isNone(context) === false);
   return guidFor(context);

--- a/index.js
+++ b/index.js
@@ -5,9 +5,15 @@ const InjectContextTransform = require('./lib/inject-context');
 module.exports = {
   name: require('./package').name,
   setupPreprocessorRegistry(type, registry) {
-    registry.add('htmlbars-ast-plugin', {
-      name: 'inject-context',
-      plugin: InjectContextTransform
-    });
+    if (type !== 'parent') {
+      return;
+    }
+    let optionalFeatures = this.project.addons.find(a => a.name === '@ember/optional-features');
+    if (optionalFeatures && optionalFeatures.isFeatureEnabled('template-only-glimmer-components') === false) {
+      registry.add('htmlbars-ast-plugin', {
+        name: 'inject-context',
+        plugin: InjectContextTransform
+      });
+    }
   }
 };

--- a/index.js
+++ b/index.js
@@ -1,5 +1,13 @@
 'use strict';
 
+const InjectContextTransform = require('./lib/inject-context');
+
 module.exports = {
-  name: require('./package').name
+  name: require('./package').name,
+  setupPreprocessorRegistry(type, registry) {
+    registry.add('htmlbars-ast-plugin', {
+      name: 'inject-context',
+      plugin: InjectContextTransform
+    });
+  }
 };

--- a/lib/inject-context.js
+++ b/lib/inject-context.js
@@ -1,0 +1,46 @@
+/* eslint-env node */
+'use strict';
+
+/*
+  ```hbs
+  {{context-id}}
+  ```
+  becomes
+  ```hbs
+  {{context-id this}
+  ```
+
+  If context is already provided nothing happen
+  ```hbs
+  {{context-id context}}
+  ```
+  becomes
+  ```hbs
+  {{context-id context}
+  ```
+*/
+
+class InjectContextTransform {
+  transform(ast) {
+    function transformNode(node) {
+      if (node.path.original === 'context-id' && node.params.length === 0) {
+          node.params.push({
+            data: false,
+            original: 'this',
+            parts: [],
+            this: true,
+            type: 'PathExpression'
+          })
+        }
+    }
+
+    this.syntax.traverse(ast, {
+      SubExpression: transformNode,
+      MustacheStatement: transformNode,
+    });
+
+    return ast;
+  }
+}
+
+module.exports = InjectContextTransform

--- a/tests/dummy/app/components/my-input.js
+++ b/tests/dummy/app/components/my-input.js
@@ -1,3 +1,0 @@
-import Component from '@ember/component'
-
-export default class MyInput extends Component {}

--- a/tests/dummy/app/templates/components/my-input.hbs
+++ b/tests/dummy/app/templates/components/my-input.hbs
@@ -1,4 +1,0 @@
-<label for={{context-id this}}>
-  {{@label}}
-</label>
-<input type="text" id={{context-id this}}/>

--- a/tests/dummy/app/templates/components/template-only-input.hbs
+++ b/tests/dummy/app/templates/components/template-only-input.hbs
@@ -1,4 +1,0 @@
-<label for={{context-id this}}>
-  {{@label}}
-</label>
-<input type="text" id={{context-id this}}/>

--- a/tests/integration/helpers/context-id-test.js
+++ b/tests/integration/helpers/context-id-test.js
@@ -4,7 +4,6 @@ import { render, /*setupOnerror,*/ findAll } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 // import { resetOnerror } from '@ember/test-helpers';
 import { guidFor } from '@ember/object/internals';
-import { helper as buildHelper } from '@ember/component/helper';
 import Ember from 'ember';
 
 module('Integration | Helper | context-id', function(hooks) {
@@ -25,36 +24,23 @@ module('Integration | Helper | context-id', function(hooks) {
   })
 
   test('It generate unique id for template only components', async function(assert) {
-    await render(hbs`<TemplateOnlyInput @label="Foo"/>`)
+    this.owner.register('template:components/foo', hbs`<span id="{{context-id}}-span">Hello world</span>`);
+    await render(hbs`<Foo/>`)
 
     assert
-      .dom('input')
-      .hasAttribute('id', /^ember.*/)
+      .dom('span')
+      .hasAttribute('id', /^ember[\d]+-span/)
   });
 
   test('Generate an unique for each instance of the same component', async function(assert) {
-    await render(hbs`
-      <MyInput @label="Foo"/>
-      <MyInput @label="Bar"/>
-    `);
+    this.owner.register('template:components/foo', hbs`<span id="{{context-id}}-span">Hello world</span>`);
+    await render(hbs`<Foo/><Foo/>`);
 
     assert
-      .dom('input')
-      .exists({ count: 2 }, 'Two inputs are rendered');
-    assert
-      .dom('label')
-      .exists({ count: 2 }, 'Two label are rendered');
-    const inputs = findAll('input');
-    const labels = findAll('label');
-    assert.notEqual(inputs[0].id, inputs[1].id, 'Inputs have different ids');
-    assert
-      .notEqual(
-        labels[0].getAttribute('for'),
-        labels[1].getAttribute('for'),
-        'Labels have different ids'
-      );
-    assert
-      .equal(inputs[0].id, labels[0].getAttribute('for'), 'Label "for" attribute has the same value has input "id" attribute');
+      .dom('span')
+      .exists({ count: 2 }, 'Two span are rendered');
+    const span = findAll('span');
+    assert.notEqual(span[0].id, span[1].id, 'Both span have different ids');
   })
 
   test('Use `this` as context by default', async function(assert) {

--- a/tests/integration/helpers/context-id-test.js
+++ b/tests/integration/helpers/context-id-test.js
@@ -4,6 +4,7 @@ import { render, /*setupOnerror,*/ findAll } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 // import { resetOnerror } from '@ember/test-helpers';
 import { guidFor } from '@ember/object/internals';
+import { helper as buildHelper } from '@ember/component/helper';
 import Ember from 'ember';
 
 module('Integration | Helper | context-id', function(hooks) {
@@ -56,7 +57,14 @@ module('Integration | Helper | context-id', function(hooks) {
       .equal(inputs[0].id, labels[0].getAttribute('for'), 'Label "for" attribute has the same value has input "id" attribute');
   })
 
-  test('Require a context', async function(assert) {
+  test('Use `this` as context by default', async function(assert) {
+    await render(hbs`{{context-id}}`);
+
+    let uniqueId = guidFor(this);
+    assert.equal(this.element.textContent.trim(), uniqueId);
+  })
+
+  test('Require a non empty context', async function(assert) {
     assert.expect(1);
     // setupOnerror(function(error) {
 
@@ -67,7 +75,6 @@ module('Integration | Helper | context-id', function(hooks) {
       // temporary fix see https://github.com/emberjs/ember-test-helpers/issues/768
     }
 
-    await render(hbs`{{context-id}}`)
+    await render(hbs`{{context-id this.context}}`)
   })
-
 });


### PR DESCRIPTION
I take inspiration from https://emberobserver.com/addons/@ember-lux/id-helper.

I've created a small ast plugin that updates invocations of `context-id` helper.
If the helper is invocated without any parameters `{{context-id}}` the plugin will update the invocation and add `this` as parameter `{{context-id this}}`.
The plugin will do nothing if the helper already as a context provided, `{{context something}}` will not be modified.