### PR TITLE
[FEAT] Make it works with glimmer template only component

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -1,5 +1,13 @@
 'use strict';
 
 module.exports = {
-  extends: 'octane'
+  extends: 'octane',
+  rules: {
+    'no-implicit-this': {
+      allow: ['context-id']
+    },
+    'no-curly-component-invocation': {
+      allow: ['context-id']
+    }
+  }
 };

--- a/addon/helpers/generate-context.js
+++ b/addon/helpers/generate-context.js
@@ -1,0 +1,20 @@
+import { helper } from '@ember/component/helper';
+import { isNone } from '@ember/utils';
+
+class DummyContext {
+  constructor() {
+    this.dummyId = dummy_context_count++;
+  }
+}
+let dummy_context_count = 0;
+/**
+ * Gerenate a string `__DUMMY-CONTEXT-X__` if the context provided is none otherwise it return the provided context.
+ * The context returned will be used by the `context-id` helper to generate unique ids
+ */
+export default helper(function(params/*, hash*/) {
+  let [context] = params;
+  if (isNone(context) === true) {
+    return new DummyContext()//`__DUMMY-CONTEXT-${dummy_context_count++}__`
+  }
+  return context;
+});

--- a/app/helpers/generate-context.js
+++ b/app/helpers/generate-context.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-context-id-helper/helpers/generate-context';

--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
 'use strict';
 
-const InjectContextTransform = require('./lib/inject-context');
+const {
+  LegacyInjectContextTransform,
+  InjectContextTransform
+} = require('./lib/inject-context');
+const VersionChecker = require('ember-cli-version-checker');
 
 module.exports = {
   name: require('./package').name,
@@ -8,12 +12,17 @@ module.exports = {
     if (type !== 'parent') {
       return;
     }
-    let optionalFeatures = this.project.addons.find(a => a.name === '@ember/optional-features');
-    if (optionalFeatures && optionalFeatures.isFeatureEnabled('template-only-glimmer-components') === false) {
-      registry.add('htmlbars-ast-plugin', {
-        name: 'inject-context',
-        plugin: InjectContextTransform
-      });
-    }
+    registry.add('htmlbars-ast-plugin', {
+      name: 'inject-context',
+      plugin: this._buildAstPlugin()
+    });
+  },
+
+  _buildAstPlugin() {
+    const checker = new VersionChecker(this.project);
+    const emberVersion = checker.for('ember-source');
+    return emberVersion.gte('3.17.0')
+      ? InjectContextTransform
+      : LegacyInjectContextTransform;
   }
 };

--- a/lib/inject-context.js
+++ b/lib/inject-context.js
@@ -7,7 +7,9 @@
   ```
   becomes
   ```hbs
-  {{context-id this}
+  {{#let (generate-context this) as |__context__|}}
+    {{context-id __context__}
+  {{/let}}
   ```
 
   If context is already provided nothing happen
@@ -19,28 +21,83 @@
   {{context-id context}
   ```
 */
-
-class InjectContextTransform {
-  transform(ast) {
-    function transformNode(node) {
-      if (node.path.original === 'context-id' && node.params.length === 0) {
+function buildTransform(blockType) {
+  return class InjectContextTransform {
+    transform(ast) {
+      debugger
+      let wrapWithGenerateContext = false;
+      function transformNode(node) {
+        if (node.path.original === 'context-id' && node.params.length === 0) {
+          wrapWithGenerateContext = true;
           node.params.push({
             data: false,
-            original: 'this',
-            parts: [],
-            this: true,
+            original: '__context__',
+            parts: ['__context__'],
+            this: false,
             type: 'PathExpression'
           })
         }
+      }
+
+      this.syntax.traverse(ast, {
+        SubExpression: transformNode,
+        MustacheStatement: transformNode,
+      });
+
+
+      if(wrapWithGenerateContext) {
+        const originalBody = ast.body;
+        ast.body = [{
+          type: 'BlockStatement',
+          path: {
+            type: 'PathExpression',
+            original: 'let',
+            this: false,
+            parts: ['let'],
+            data: false,
+          },
+          params: [{
+            type: 'SubExpression',
+            path: {
+              type: 'PathExpression',
+              original: 'generate-context',
+              this: false,
+              parts: ['generate-context'],
+              data: false,
+            },
+            params: [{
+              type: 'PathExpression',
+              original: 'this',
+              this: true,
+              parts: [],
+              data: false
+            }],
+            hash: { type: 'Hash', pairs: [] },
+          }],
+          hash: { type: 'Hash', pairs: [] },
+          program: {
+            type: blockType,
+            body: originalBody,
+            blockParams: ['__context__'],
+            chained: false,
+          },
+          inverse: null,
+          openStrip: { open: false, close: false },
+          inverseStrip: { open: false, close: false },
+          closeStrip: { open: false, close: false },
+        }];
+      }
+
+      return ast;
     }
-
-    this.syntax.traverse(ast, {
-      SubExpression: transformNode,
-      MustacheStatement: transformNode,
-    });
-
-    return ast;
   }
 }
 
-module.exports = InjectContextTransform
+// ember updated glimmer in 3.17.
+// and this glimmer update changed the type from
+// 'Program' to 'Block'.
+// so we can construct both versions here.
+module.exports = {
+  LegacyInjectContextTransform: buildTransform('Program'),
+  InjectContextTransform: buildTransform('Block'),
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6776,6 +6776,34 @@
         "fixturify-project": "^1.10.0",
         "rimraf": "^3.0.1",
         "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "ember-cli-version-checker": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-4.1.1.tgz",
+          "integrity": "sha512-bzEWsTMXUGEJfxcAGWPe6kI7oHEGD3jaxUWDYPTqzqGhNkgPwXTBgoWs9zG1RaSMaOPFnloWuxRcoHi4TrYS3Q==",
+          "requires": {
+            "resolve-package-path": "^2.0.0",
+            "semver": "^6.3.0",
+            "silent-error": "^1.1.1"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+            }
+          }
+        },
+        "resolve-package-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-2.0.0.tgz",
+          "integrity": "sha512-/CLuzodHO2wyyHTzls5Qr+EFeG6RcW4u6//gjYvUfcfyuplIX1SSccU+A5A9A78Gmezkl3NBkFAMxLbzTY9TJA==",
+          "requires": {
+            "path-root": "^0.1.1",
+            "resolve": "^1.13.1"
+          }
+        }
       }
     },
     "ember-cli-babel-plugin-helpers": {
@@ -7231,12 +7259,12 @@
       }
     },
     "ember-cli-version-checker": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-4.1.0.tgz",
-      "integrity": "sha512-yLf2YqotTSsjiXwx9Dt6H7AU0QcldFn5SLk/pG3Zqb0aHNeanBOPlx4/Ysa46ILGWYIh0fDH34AEVRueXTrQBQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.1.tgz",
+      "integrity": "sha512-YziSW1MgOuVdJSyUY2CKSC4vXrGQIHF6FgygHkJOxYGjZNQYwf5MK0sbliKatvJf7kzDSnXs+r8JLrD74W/A8A==",
       "requires": {
         "resolve-package-path": "^2.0.0",
-        "semver": "^6.3.0",
+        "semver": "^7.3.2",
         "silent-error": "^1.1.1"
       },
       "dependencies": {
@@ -7250,9 +7278,9 @@
           }
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.17.2",
-    "ember-cli-htmlbars": "^4.2.2"
+    "ember-cli-htmlbars": "^4.2.2",
+    "ember-cli-version-checker": "^5.1.1"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",


### PR DESCRIPTION
One again I've taken inspiration from [@ember-lux/id-helper](https://emberobserver.com/addons/@ember-lux/id-helper) to add support for glimmer template only components.

In this PR I've updated the AST plugin added in the v0.2.0 to add the possibility to use `context-id` without a context in glimmer template only components.
The AST plugin used to update the templates at build time like this:

```
// Uses of context-id without an argument
{{context-id}}
// Were transformed into
{{context-id this}}

// Uses of context-id with an argument
{{context-id context}}
// were not updated
{{context-id context}}
```

But the problem is that in glimmer template only component `this` is not defined so the AST cannot be used.

To make it works with glimmer template only components, I've updated the AST plugin like this.

```
// Uses of context-id without an argument
... template content
{{context-id}}
.... template content
// Are transformed into
{{#let (generate-context this) as |__context__|}}
    ... template content
    {{context-id __context__}}
    ... template content
{{/let}}

// Uses of context-id with an argument
{{context-id context}}
// Are still not updated
{{context-id context}}
```

Now all templates using `context-id` without an argument are updated and wrapped inside a `{{let}}` block. The `let` block use the new helper `generate-context` to generate and expose the variable `__context__` which is injected in all invocations of `context-id`.

The helper `generate-context` generates a dummy object if the argument provided is empty. In the AST plugin this helper is used the following way `(generate-context this)`. By doing this, we ensure that `__context__` will equal `this` for components that are not template only and for template only components `__context__` will be a unique object. 